### PR TITLE
Use val verde mingw fork

### DIFF
--- a/ubuntu20.04/mingw-sdk.modulemap
+++ b/ubuntu20.04/mingw-sdk.modulemap
@@ -103,6 +103,8 @@ module mingw [system] {
       }
     }
   }
+
+  link "ucrt"
 }
 
 module win32 {
@@ -122,4 +124,5 @@ module win32 {
   header "shlobj.h"
   header "ws2tcpip.h"
   export *
+  link "ucrt"
 }

--- a/ubuntu20.04/ubuntu.Dockerfile
+++ b/ubuntu20.04/ubuntu.Dockerfile
@@ -532,7 +532,7 @@ COPY mingw-sdk.modulemap \
 # mingw-w64 source
 RUN export SOURCE_PACKAGE_NAME=mingw-w64 \
     && export SOURCE_ROOT=/sources/${SOURCE_PACKAGE_NAME} \
-    && git clone https://github.com/mirror/mingw-w64.git --single-branch --branch master ${SOURCE_ROOT}
+    && git clone https://github.com/val-verde/mingw-w64.git --single-branch --branch master ${SOURCE_ROOT}
 
 # windows mingw-headers build
 FROM WINDOWS_SOURCES_BUILDER AS WINDOWS_MINGW_HEADERS_BUILDER

--- a/ubuntu20.04/ubuntu.Dockerfile
+++ b/ubuntu20.04/ubuntu.Dockerfile
@@ -625,9 +625,9 @@ RUN export LIBS="-lc++abi -lunwind" \
 # windows icu build
 FROM WINDOWS_LIBCXX_BUILDER AS WINDOWS_ICU_BUILDER
 
-RUN export LDFLAGS="-fuse-ld=${PACKAGE_ROOT}/bin/${TARGET_PROCESSOR}-${TARGET_KERNEL}-${TARGET_OS}-ld" \
-           LIBS="-lmingwex -lmsvcrt -lmingw32 -lmsvcr120_app -lc++abi -lunwind" \
-    && bash ${PACKAGE_BASE_NAME}-platform-sdk-icu4c-cross || true
+RUN export LDFLAGS="-fuse-ld=${PACKAGE_ROOT}/bin/${PACKAGE_BASE_NAME}-platform-sdk-mslink" \
+           LIBS="-lc++abi -lucrt -lunwind" \
+    && bash ${PACKAGE_BASE_NAME}-platform-sdk-icu4c-cross
 
 # windows xz build
 FROM WINDOWS_ICU_BUILDER AS WINDOWS_XZ_BUILDER

--- a/ubuntu20.04/ubuntu.Dockerfile
+++ b/ubuntu20.04/ubuntu.Dockerfile
@@ -774,10 +774,10 @@ RUN export CFLAGS="-fms-extensions -fms-compatibility-version=19.2" \
                         -L${SYSROOT}/lib/swift/windows/${HOST_PROCESSOR}" \
     && bash ${PACKAGE_BASE_NAME}-platform-sdk-swift-corelibs-xctest-windows
 RUN dpkg -i /sources/${PACKAGE_BASE_NAME}-swift-corelibs-foundation-${BUILD_OS}-${BUILD_PROCESSOR}.deb \
-            /sources/${PACKAGE_BASE_NAME}-swift-corelibs-libdispatch-${BUILD_OS}-${BUILD_PROCESSOR}.deb
+            /sources/${PACKAGE_BASE_NAME}-swift-corelibs-libdispatch-${BUILD_OS}-${BUILD_PROCESSOR}.deb \
+            /sources/${PACKAGE_BASE_NAME}-swift-corelibs-libdispatch-${HOST_OS}${HOST_OS_API_LEVEL}-${HOST_PROCESSOR}.deb
 
 # HACK: Enable these when Windows Foundation is built.
-# /sources/${PACKAGE_BASE_NAME}-swift-corelibs-libdispatch-${HOST_OS}${HOST_OS_API_LEVEL}-${HOST_PROCESSOR}.deb \
 # /sources/${PACKAGE_BASE_NAME}-swift-corelibs-foundation-${HOST_OS}${HOST_OS_API_LEVEL}-${HOST_PROCESSOR}.deb \
 
 RUN cp /sources/build-staging/swift-corelibs-foundation-mingw32-x86_64/Sources/Foundation/lib*.dll \
@@ -788,13 +788,6 @@ RUN cp /sources/build-staging/swift-corelibs-foundation-mingw32-x86_64/Sources/F
           ${SYSROOT}/lib/swift/windows/ \
     && cp /sources/build-staging/swift-corelibs-foundation-mingw32-x86_64/swift/*.swift* \
           ${SYSROOT}/lib/swift/windows/${HOST_PROCESSOR} \
-    && cp /sources/build-staging/swift-corelibs-libdispatch-mingw32-x86_64/lib*.dll \
-          ${SYSROOT}/lib/swift/windows/ \
-    && cp /sources/build-staging/swift-corelibs-libdispatch-mingw32-x86_64/src/swift/lib*.a \
-          ${SYSROOT}/lib/swift/windows/ \
-    && cp /sources/build-staging/swift-corelibs-libdispatch-mingw32-x86_64/src/swift/swift/*.swift* \
-          ${SYSROOT}/lib/swift/windows/${HOST_PROCESSOR} \
-    && cp -r ${PACKAGE_ROOT}/lib/swift/dispatch ${SYSROOT}/lib/swift \
     && cp -r ${PACKAGE_ROOT}/lib/swift/CoreFoundation ${SYSROOT}/lib/swift
 
 # windows llbuild build

--- a/ubuntu20.04/val-verde-platform-sdk-mslink
+++ b/ubuntu20.04/val-verde-platform-sdk-mslink
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+set -e
+
 args=$@
-args=`echo ${args}|sed -r 's/-implib/\/implib/g'`
+args=`echo ${args}|sed -r 's/-implib:/\/implib:/g'`
+args=`echo ${args}|sed -r 's/-Bsymbolic//g'`
 
 ${PACKAGE_ROOT}/bin/ld.lld ${args}

--- a/ubuntu20.04/val-verde-platform-sdk-swift-windows
+++ b/ubuntu20.04/val-verde-platform-sdk-swift-windows
@@ -66,6 +66,12 @@ ${PACKAGE_BASE_NAME}-platform-sdk-cmake \
 
 # Package the components
 source /sources/${PACKAGE_BASE_NAME}-platform-sdk-ninja-build
+
+rm -f install${PACKAGE_ROOT}/${PACKAGE_BASE_NAME}-platform-sdk-${HOST_OS}${HOST_OS_API_LEVEL}-${HOST_PROCESSOR}/sysroot/bin/*libdispatch* \
+      install${PACKAGE_ROOT}/${PACKAGE_BASE_NAME}-platform-sdk-${HOST_OS}${HOST_OS_API_LEVEL}-${HOST_PROCESSOR}/sysroot/bin/*BlocksRuntime* \
+      install${PACKAGE_ROOT}/${PACKAGE_BASE_NAME}-platform-sdk-${HOST_OS}${HOST_OS_API_LEVEL}-${HOST_PROCESSOR}/sysroot/lib/*libdispatch* \
+      install${PACKAGE_ROOT}/${PACKAGE_BASE_NAME}-platform-sdk-${HOST_OS}${HOST_OS_API_LEVEL}-${HOST_PROCESSOR}/sysroot/lib/*BlocksRuntime*
+
 source /sources/${PACKAGE_BASE_NAME}-platform-sdk-package-build
 
 # Build the package


### PR DESCRIPTION
This patch set fixes a few issues:
1. Fix mingw-w64 repo link to val-verde fork.
2. Fix mslink helper script to prune -Bsymbolic. Also fix up -implib handling to avoid cases like -out-implib.
3. Remove hack for libdispatch on Windows and properly install it.