### PR TITLE
Fix icu and openssl rpath specification

### DIFF
--- a/backends/bash/cross/val-verde-platform-sdk-icu4c-cross
+++ b/backends/bash/cross/val-verde-platform-sdk-icu4c-cross
@@ -10,6 +10,12 @@ if [ "${BUILD_TRIPLE}" != "${HOST_TRIPLE}" ]; then
     CROSS_BUILD_CMD="--with-cross-build=${STAGE_ROOT_BASE}/${SOURCE_PACKAGE_NAME}-${SOURCE_PACKAGE_VERSION}-${BUILD_OS}${BUILD_OS_API_LEVEL}-${BUILD_CPU}/build"
 fi
 
+ENABLE_OR_DISABLE_RPATH=enable
+
+if [ "${HOST_OS}" = "mingw32" ]; then
+    ENABLE_OR_DISABLE_RPATH=disable
+fi
+
 CONFIGURE_FILE_ROOT=${STAGE_ROOT}/${SOURCE_PACKAGE_NAME}/source \
 DISABLE_AUTOUPDATE=TRUE \
 RPATH_COMPONENTS="\
@@ -26,4 +32,5 @@ package-stage-configure-install-archive \
     --enable-shared \
     --enable-tools \
     --with-library-suffix=swift \
+    --${ENABLE_OR_DISABLE_RPATH}-rpath \
     ${CROSS_BUILD_CMD}

--- a/backends/bash/cross/val-verde-platform-sdk-openssl-cross
+++ b/backends/bash/cross/val-verde-platform-sdk-openssl-cross
@@ -26,8 +26,8 @@ elif [ "${HOST_OS}" = "macos" ]; then
         OPENSSL_PROCESSOR=arm64
     fi
 elif [ "${HOST_OS}" = "mingw32" ]; then
-    OPENSSL_OS=mingw64
     OPENSSL_DIR=${PACKAGE_PREFIX}/etc/ssl
+    OPENSSL_OS=mingw64
 fi
 
 OPENSSL_TARGET=${OPENSSL_OS}-${OPENSSL_PROCESSOR}
@@ -40,10 +40,9 @@ LD=${CCLD} \
 LDFLAGS=${CCLDFLAGS} \
 TOOL_LOG=${STAGE_ROOT}/builder-invocation \
 tool-log ${SOURCE_ROOT}/Configure \
-    --libdir=${PACKAGE_PREFIX}/lib \
+    --libdir=lib \
     --openssldir=${OPENSSL_DIR} \
     --prefix=${PACKAGE_PREFIX} \
-    ${OPENSSL_DEFINES} \
     ${OPENSSL_TARGET}
 
 # Build the components


### PR DESCRIPTION
MacOS builds do not product valid rpaths, this can be attributed to incorrect specification setting in the icu and openssl builder.